### PR TITLE
6916: Edit Supplier section - subsequent times

### DIFF
--- a/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
@@ -316,9 +316,13 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 		public void EnterContact(Contact contact)
 		{
 			Wait.Until(d => d.FindElements(Pages.OrderForm.ContactFirstName).Count == 1);
+			Driver.FindElement(Pages.OrderForm.ContactFirstName).Clear();
 			Driver.FindElement(Pages.OrderForm.ContactFirstName).SendKeys(contact.FirstName);
+			Driver.FindElement(Pages.OrderForm.ContactLastName).Clear();
 			Driver.FindElement(Pages.OrderForm.ContactLastName).SendKeys(contact.LastName);
+			Driver.FindElement(Pages.OrderForm.ContactEmail).Clear();
 			Driver.FindElement(Pages.OrderForm.ContactEmail).SendKeys(contact.Email);
+			Driver.FindElement(Pages.OrderForm.ContactTelephone).Clear();
 			Driver.FindElement(Pages.OrderForm.ContactTelephone).SendKeys(contact.Phone);
 		}
 

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CallOffOrderingParty.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CallOffOrderingParty.cs
@@ -96,20 +96,10 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Context.Add("CreatedAddress", dbAddress);
 
             var expectedContact = (Contact)Context["ExpectedContact"];
-            dbContact.FirstName.Should().BeEquivalentTo(expectedContact.FirstName);
-            dbContact.LastName.Should().BeEquivalentTo(expectedContact.LastName);
-            dbContact.Email.Should().BeEquivalentTo(expectedContact.Email);
-            dbContact.Phone.Should().BeEquivalentTo(expectedContact.Phone);
+            dbContact.Equals(expectedContact);
 
             var expectedAddress = (Address)Context["ExpectedAddress"];
-            dbAddress.Line1.Should().BeEquivalentTo(expectedAddress.Line1);
-            dbAddress.Line2.Should().BeEquivalentTo(expectedAddress.Line2);
-            dbAddress.Line3.Should().BeEquivalentTo(expectedAddress.Line3);
-            dbAddress.Line4.Should().BeEquivalentTo(expectedAddress.Line4);
-            dbAddress.Town.Should().BeEquivalentTo(expectedAddress.Town);
-            dbAddress.County.Should().BeEquivalentTo(expectedAddress.County);
-            dbAddress.Postcode.Should().BeEquivalentTo(expectedAddress.Postcode);
-            dbAddress.Country.Should().BeEquivalentTo(expectedAddress.Country);
+            dbAddress.Equals(expectedAddress);
         }
 
     }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
@@ -75,7 +75,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Context.Add("CreatedOrder", order);
         }
 
-        [When(@"the Order Form for the existing order is presented")]
+        [StepDefinition(@"the Order Form for the existing order is presented")]
         public void WhenTheOrderFormForTheExistingOrderIsPresented()
         {
             GivenThatABuyerUserHasLoggedIn();

--- a/src/OrderFormAcceptanceTests.Steps/Steps/SupplierInformation.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/SupplierInformation.cs
@@ -17,6 +17,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         }
 
         [Then(@"the user is able to manage the Supplier section")]
+        [StepDefinition(@"the User re-edits the Supplier section")]
         public void ThenTheUserIsAbleToManageTheSupplierSection()
         {
             Test.Pages.OrderForm.ClickEditSupplier();
@@ -147,6 +148,12 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrderForm.SearchAgainLinkIsDisplayed().Should().BeTrue();
         }
 
+        [Then(@"there is not a control available to search again for a Supplier")]
+        public void ThenThereIsNotAControlAvailableToSearchAgainForASupplier()
+        {
+            Test.Pages.OrderForm.SearchAgainLinkIsDisplayed().Should().BeFalse();
+        }
+
         [When(@"the User chooses to search again for a Supplier")]
         public void WhenTheUserChoosesToSearchAgainForASupplier()
         {
@@ -168,30 +175,23 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             var order = (Order)Context["CreatedOrder"];
             var expectedSupplierName = order.SupplierName;
             order = order.Retrieve(Test.ConnectionString);
+
             var dbContact = new Contact { ContactId = order.SupplierContactId }.Retrieve(Test.ConnectionString);
-            Context.Add("CreatedContact", dbContact);
+            Context.Remove("CreatedSupplierContact");
+            Context.Add("CreatedSupplierContact", dbContact);            
 
             var dbAddress = new Address { AddressId = order.SupplierAddressId }.Retrieve(Test.ConnectionString);
-            Context.Add("CreatedAddress", dbAddress);
+            Context.Remove("CreatedSupplierAddress");
+            Context.Add("CreatedSupplierAddress", dbAddress);
 
             order.SupplierName.Should().BeEquivalentTo(expectedSupplierName);
             order.SupplierId.Should().NotBeNull();
 
             var expectedContact = (Contact)Context["ExpectedContact"];
-            dbContact.FirstName.Should().BeEquivalentTo(expectedContact.FirstName);
-            dbContact.LastName.Should().BeEquivalentTo(expectedContact.LastName);
-            dbContact.Email.Should().BeEquivalentTo(expectedContact.Email);
-            dbContact.Phone.Should().BeEquivalentTo(expectedContact.Phone);
+            dbContact.Equals(expectedContact);
 
             var expectedAddress = (Address)Context["ExpectedAddress"];
-            dbAddress.Line1.Should().BeEquivalentTo(expectedAddress.Line1);
-            dbAddress.Line2.Should().BeEquivalentTo(expectedAddress.Line2);
-            dbAddress.Line3.Should().BeEquivalentTo(expectedAddress.Line3);
-            dbAddress.Line4.Should().BeEquivalentTo(expectedAddress.Line4);
-            dbAddress.Town.Should().BeEquivalentTo(expectedAddress.Town);
-            dbAddress.County.Should().BeEquivalentTo(expectedAddress.County);
-            dbAddress.Postcode.Should().BeEquivalentTo(expectedAddress.Postcode);
-            dbAddress.Country.Should().BeEquivalentTo(expectedAddress.Country);
+            dbAddress.Equals(expectedAddress);
         }
 
     }

--- a/src/OrderFormAcceptanceTests.TestData/Address.cs
+++ b/src/OrderFormAcceptanceTests.TestData/Address.cs
@@ -1,10 +1,8 @@
 ﻿using Bogus;
+using FluentAssertions;
 using OrderFormAcceptanceTests.TestData.Utils;
-using System;
-using System.CodeDom.Compiler;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+
 
 namespace OrderFormAcceptanceTests.TestData
 {
@@ -20,6 +18,36 @@ namespace OrderFormAcceptanceTests.TestData
           public string County { get; set; }
           public string Postcode { get; set; }
           public string Country { get; set; }
+
+        public void Equals(Address address)
+        {
+            this.Line1 = this.Line1 == "" ? null : this.Line1;
+            this.Line2 = this.Line2 == "" ? null : this.Line2;
+            this.Line3 = this.Line3 == "" ? null : this.Line3;
+            this.Line4 = this.Line4 == "" ? null : this.Line4;
+            this.Town = this.Town == "" ? null : this.Town;
+            this.County = this.County == "" ? null : this.County;
+            this.Postcode = this.Postcode == "" ? null : this.Postcode;
+            this.Country = this.Country == "" ? null : this.Country;
+
+            address.Line1 = address.Line1 == "" ? null : address.Line1;
+            address.Line2 = address.Line2 == "" ? null : address.Line2;
+            address.Line3 = address.Line3 == "" ? null : address.Line3;
+            address.Line4 = address.Line4 == "" ? null : address.Line4;
+            address.Town = address.Town == "" ? null : address.Town;
+            address.County = address.County == "" ? null : address.County;
+            address.Postcode = address.Postcode == "" ? null : address.Postcode;
+            address.Country = address.Country == "" ? null : address.Country;
+
+            this.Line1.Should().BeEquivalentTo(address.Line1);
+            this.Line2.Should().BeEquivalentTo(address.Line2);
+            this.Line3.Should().BeEquivalentTo(address.Line3);
+            this.Line4.Should().BeEquivalentTo(address.Line4);
+            this.Town.Should().BeEquivalentTo(address.Town);
+            this.County.Should().BeEquivalentTo(address.County);
+            this.Postcode.Should().BeEquivalentTo(address.Postcode);
+            this.Country.Should().BeEquivalentTo(address.Country);
+        }
 
         public Address Generate()
         {

--- a/src/OrderFormAcceptanceTests.TestData/Contact.cs
+++ b/src/OrderFormAcceptanceTests.TestData/Contact.cs
@@ -1,9 +1,7 @@
 ﻿using Bogus;
+using FluentAssertions;
 using OrderFormAcceptanceTests.TestData.Utils;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace OrderFormAcceptanceTests.TestData
 {
@@ -14,6 +12,14 @@ namespace OrderFormAcceptanceTests.TestData
         public string LastName { get; set; }
         public string Email { get; set; }
         public string Phone { get; set; }
+
+        public void Equals(Contact contact)
+        {
+            this.FirstName.Should().BeEquivalentTo(contact.FirstName);
+            this.LastName.Should().BeEquivalentTo(contact.LastName);
+            this.Email.Should().BeEquivalentTo(contact.Email);
+            this.Phone.Should().BeEquivalentTo(contact.Phone);
+        }
 
         public Contact Generate()
         {

--- a/src/OrderFormAcceptanceTests.TestData/OrderFormAcceptanceTests.TestData.csproj
+++ b/src/OrderFormAcceptanceTests.TestData/OrderFormAcceptanceTests.TestData.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Dapper" Version="2.0.35" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>
 
 </Project>

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/SupplierInformation.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/SupplierInformation.feature
@@ -154,3 +154,33 @@ Scenario: Supplier Information - Go Back (first time)
 	And mandatory data are missing 
 	When the User chooses to go back
 	Then the matching Suppliers are presented
+
+
+Scenario: Supplier Information - Edit (subsequent times)
+	Given an unsubmitted order exists
+	And the Order Form for the existing order is presented
+	When the User re-edits the Supplier section
+	Then the Edit Supplier Form Page is presented
+	And there is not a control available to search again for a Supplier
+	And the Supplier name is autopopulated
+	And the Supplier Registered Address is autopopulated
+	And the Supplier Contact details are autopopulated
+
+Scenario: Supplier Information - Edit and save (subsequent times)
+	Given an unsubmitted order exists
+	And the Order Form for the existing order is presented
+	And the User re-edits the Supplier section
+	And the user has entered a valid supplier contact for the order
+	And makes a note of the autopopulated Supplier details
+	When the User chooses to save
+	Then the Order is saved
+	And the content validation status of the supplier section is complete
+	And the Supplier section is saved in the DB
+
+Scenario: Supplier Information - Go Back (subsequent times)
+	Given an unsubmitted order exists
+	And the Order Form for the existing order is presented
+	And the User re-edits the Supplier section
+	And the Edit Supplier Form Page is presented
+	When the User chooses to go back
+	Then the Order dashboard is presented


### PR DESCRIPTION
implemented scenarios
Made the executive decision not to implement scenarios 2 4 & 6 as it would just be clearing the fields and testing the form validation again.
[AB#7149](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7149)