### PR TITLE
7429: added supplier addresses and contacts

### DIFF
--- a/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using OpenQA.Selenium;
 using OrderFormAcceptanceTests.Actions.Utils;
 using OrderFormAcceptanceTests.Steps.Utils;
 using OrderFormAcceptanceTests.TestData;
@@ -38,12 +39,25 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         }
 
         [Given(@"mandatory data are missing")]
-        [Then(@".* section is not saved")]
         [When(@"the User has not entered a Supplier search criterion")]
-        [Given(@"no Supplier is selected")]
         public void GivenMandatoryDataAreMissing()
         {
+            //clear fields
+            //var listOfTextAreas = Test.Driver.FindElements(By.TagName("textarea"));
+            var listOfInputs = Test.Driver.FindElements(By.ClassName("nhsuk-input"));
+            foreach(var element in listOfInputs)
+            {
+                element.Clear();
+            }
+
+        }
+
+        [Then(@".* section is not saved")]
+        [Given(@"no Supplier is selected")]
+        public void DoNothing()
+        {
             //do nothing
+
         }
 
         [Given(@"an unsubmitted order exists")]

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/SupplierInformation.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/SupplierInformation.feature
@@ -87,7 +87,7 @@ Scenario: Supplier Information - Go Back (No Supplier(s) returned)
 	And no matching Suppliers are presented
 	When the User chooses to go back
 	Then the Search supplier screen is presented
-	@ignore
+	
 Scenario: Supplier Information - Supplier selected
 	Given the User has been presented with matching Suppliers
 	When they select a Supplier
@@ -131,6 +131,7 @@ Scenario: Supplier Information - Data exceeds the maximum length
 
 Scenario: Supplier Information - Validation Error Message Anchors
 	Given the User has selected a supplier for the first time
+	And mandatory data are missing
 	And the validation has been triggered
 	When the user selects an error link in the Error Summary
 	Then they will be navigated to the relevant part of the page


### PR DESCRIPTION
Now that the address and suppliers have been added to the DB in Dev and Test, enabled the scenario which expects them.
This also meant I needed to update the tests which were testing validation to make sure said contact fields were cleared
