### PR TITLE
7260: Add a single Catalogue Solution - select price

### DIFF
--- a/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
@@ -528,10 +528,12 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 			return Driver.FindElements(Pages.Common.RadioButton).Count;
 		}
 
-		public void ClickRadioButton(int index = 0)
+		public string ClickRadioButton(int index = 0)
 		{
 			Wait.Until(d => NumberOfRadioButtonsDisplayed() > index);
-			Driver.FindElements(Pages.Common.RadioButton)[index].Click();
+			var element = Driver.FindElements(Pages.Common.RadioButton)[index];
+			element.Click();
+			return element.GetAttribute("value");
 		}
 	}
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -1,8 +1,10 @@
 ﻿using FluentAssertions;
 using OrderFormAcceptanceTests.Steps.Utils;
 using OrderFormAcceptanceTests.TestData;
+using OrderFormAcceptanceTests.TestData.Utils;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using TechTalk.SpecFlow;
 
@@ -124,17 +126,18 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         [Given(@"the User selects a catalogue solution to add")]
         public void GivenTheUserSelectsACatalogueSolutionToAdd()
         {
-            Test.Pages.OrderForm.ClickRadioButton();
+            var solutionId = Test.Pages.OrderForm.ClickRadioButton();
+            Context.Add("ChosenSolutionId", solutionId);
         }
 
         [Then(@"all the available prices for that Catalogue Solution are presented")]
         public void ThenAllTheAvailablePricesForThatCatalogueSolutionArePresented()
         {
-            //get solution from DB
-            //get all prices for solution from DB
-            var expectedNumberOfPrices = 0;
+            Test.Pages.OrderForm.EditNamedSectionPageDisplayed("List price").Should().BeTrue();
+            var SolutionId = (string)Context["ChosenSolutionId"];
+            var query = "Select count(*) FROM [dbo].[PurchasingModel] where [dbo].[PurchasingModel].SolutionId=@SolutionId";
+            var expectedNumberOfPrices = SqlExecutor.Execute<int>(Test.BapiConnectionString, query, new { SolutionId }).Single();
             Test.Pages.OrderForm.NumberOfRadioButtonsDisplayed().Should().Be(expectedNumberOfPrices);
-            Context.Pending();
         }
 
         [Given(@"the User is presented with the prices for the selected Catalogue Solution")]

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -135,7 +135,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         {
             Test.Pages.OrderForm.EditNamedSectionPageDisplayed("List price").Should().BeTrue();
             var SolutionId = (string)Context["ChosenSolutionId"];
-            var query = "Select count(*) FROM [dbo].[PurchasingModel] where [dbo].[PurchasingModel].SolutionId=@SolutionId";
+            var query = "Select count(*) FROM [dbo].[PurchasingModel] where SolutionId=@SolutionId";
             var expectedNumberOfPrices = SqlExecutor.Execute<int>(Test.BapiConnectionString, query, new { SolutionId }).Single();
             Test.Pages.OrderForm.NumberOfRadioButtonsDisplayed().Should().Be(expectedNumberOfPrices);
         }
@@ -147,13 +147,6 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             GivenTheUserSelectsACatalogueSolutionToAdd();
             new CommonSteps(Test, Context).WhenTheyChooseToContinue();
             ThenTheyCanSelectOneRadioButton();
-        }
-
-        [Then(@"the User's selected Catalogue Solution is selected")]
-        public void ThenTheUserSSelectedCatalogueSolutionIsSelected()
-        {
-            //radio button is selected?
-            Context.Pending();
         }
     }
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -91,7 +91,8 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         }
 
         [Then(@"they can select one Catalogue Solution to add")]
-        public void ThenTheyCanSelectOneCatalogueSolutionToAdd()
+        [Then(@"they can select a price for the Catalogue Solution")]
+        public void ThenTheyCanSelectOneRadioButton()
         {
             Test.Pages.OrderForm.NumberOfRadioButtonsDisplayed().Should().BeGreaterThan(0);
         }
@@ -112,5 +113,44 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrderForm.ClickOnErrorLink().Should().ContainEquivalentOf("selectSolution");
         }
 
+        [Then(@"the User is informed they have to select a Catalogue Solution price")]
+        public void ThenTheUserIsInformedTheyHaveToSelectACatalogueSolutionPrice()
+        {
+            Test.Pages.OrderForm.ErrorSummaryDisplayed().Should().BeTrue();
+            Test.Pages.OrderForm.ErrorMessagesDisplayed().Should().BeTrue();
+            Test.Pages.OrderForm.ClickOnErrorLink().Should().ContainEquivalentOf("selectSolutionPrice");
+        }
+
+        [Given(@"the User selects a catalogue solution to add")]
+        public void GivenTheUserSelectsACatalogueSolutionToAdd()
+        {
+            Test.Pages.OrderForm.ClickRadioButton();
+        }
+
+        [Then(@"all the available prices for that Catalogue Solution are presented")]
+        public void ThenAllTheAvailablePricesForThatCatalogueSolutionArePresented()
+        {
+            //get solution from DB
+            //get all prices for solution from DB
+            var expectedNumberOfPrices = 0;
+            Test.Pages.OrderForm.NumberOfRadioButtonsDisplayed().Should().Be(expectedNumberOfPrices);
+            Context.Pending();
+        }
+
+        [Given(@"the User is presented with the prices for the selected Catalogue Solution")]
+        public void GivenTheUserIsPresentedWithThePricesForTheSelectedCatalogueSolution()
+        {
+            GivenTheUserIsPresentedWithCatalogueSolutionsAvailableFromTheirChosenSupplier();
+            GivenTheUserSelectsACatalogueSolutionToAdd();
+            new CommonSteps(Test, Context).WhenTheyChooseToContinue();
+            ThenTheyCanSelectOneRadioButton();
+        }
+
+        [Then(@"the User's selected Catalogue Solution is selected")]
+        public void ThenTheUserSSelectedCatalogueSolutionIsSelected()
+        {
+            //radio button is selected?
+            Context.Pending();
+        }
     }
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
@@ -59,6 +59,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         [Given(@"the Call Off Ordering Party is not selected")]
         [Given(@"the User chooses not to add a Catalogue Solution")]
         [Given(@"no Catalogue Solution is selected")]
+        [Given(@"no Catalogue Solution price is selected")]
         public void DoNothing()
         {
             //do nothing

--- a/src/OrderFormAcceptanceTests.Steps/Utils/EnvironmentVariables.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Utils/EnvironmentVariables.cs
@@ -54,6 +54,15 @@ namespace OrderFormAcceptanceTests.Steps.Utils
             return string.Format(ConnectionString.GPitFutures, serverUrl, databaseName, dbUser, dbPassword);
         }
 
+        internal static string BapiDbConnectionString()
+        {
+            var (serverUrl, databaseName, dbUser, dbPassword) = DbConnectionDetails();
+
+            databaseName = Environment.GetEnvironmentVariable("BAPIDATABASENAME") ?? "buyingcatalogue";
+
+            return string.Format(ConnectionString.GPitFutures, serverUrl, databaseName, dbUser, dbPassword);
+        }
+
         private static string JsonConfigValues(string section, string defaultValue)
         {
             var path = Path.Combine(Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory), "Utils",

--- a/src/OrderFormAcceptanceTests.Steps/Utils/UITest.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Utils/UITest.cs
@@ -7,6 +7,7 @@ namespace OrderFormAcceptanceTests.Steps.Utils
     public sealed class UITest
     {
         internal string ConnectionString;
+        internal string BapiConnectionString;
         internal IWebDriver Driver;
         internal PageActionCollection Pages;
         internal readonly string Url;
@@ -14,6 +15,7 @@ namespace OrderFormAcceptanceTests.Steps.Utils
         public UITest()
         {
             ConnectionString = EnvironmentVariables.DbConnectionString();
+            BapiConnectionString = EnvironmentVariables.BapiDbConnectionString();
 
             Driver = new BrowserFactory().Driver;
             Pages = new PageActions(Driver).PageActionCollection;

--- a/src/OrderFormAcceptanceTests.TestData/Utils/SqlExecutor.cs
+++ b/src/OrderFormAcceptanceTests.TestData/Utils/SqlExecutor.cs
@@ -4,9 +4,9 @@ using System.Data.SqlClient;
 
 namespace OrderFormAcceptanceTests.TestData.Utils
 {
-    internal static class SqlExecutor
+    public static class SqlExecutor
     {
-        internal static IEnumerable<T> Execute<T>(string connectionString, string query, object param)
+        public static IEnumerable<T> Execute<T>(string connectionString, string query, object param)
         {
             IEnumerable<T> returnValue = null;
             using (var connection = new SqlConnection(connectionString))
@@ -18,7 +18,7 @@ namespace OrderFormAcceptanceTests.TestData.Utils
             return returnValue;
         }
 
-        internal static int ExecuteScalar(string connectionString, string query, object param)
+        public static int ExecuteScalar(string connectionString, string query, object param)
         {
             var result = 0;
             using (var connection = new SqlConnection(connectionString))

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -93,4 +93,3 @@ Scenario: Catalogue Solutions - Go back from select price
 	Given the User is presented with the prices for the selected Catalogue Solution
 	When the User chooses to go back
 	Then they are presented with the Catalogue Solutions available from their chosen Supplier
-	And the User's selected Catalogue Solution is selected

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -75,3 +75,22 @@ Scenario: Catalogue Solutions - Go back from select a solution
 	Given the User is presented with Catalogue Solutions available from their chosen Supplier
 	When the User chooses to go back
 	Then the Catalogue Solution dashboard is presented
+	@ignore
+Scenario: Catalogue Solutions - Select a price for the Catalogue Solution
+	Given the User is presented with Catalogue Solutions available from their chosen Supplier
+	And the User selects a catalogue solution to add
+	When they choose to continue
+	Then all the available prices for that Catalogue Solution are presented
+	And they can select a price for the Catalogue Solution
+	@ignore
+Scenario: Catalogue Solutions - No price for the Catalogue Solution selected
+	Given the User is presented with the prices for the selected Catalogue Solution 
+	And no Catalogue Solution price is selected
+	When they choose to continue
+	Then the User is informed they have to select a Catalogue Solution price
+	@ignore
+Scenario: Catalogue Solutions - Go back from select price
+	Given the User is presented with the prices for the selected Catalogue Solution
+	When the User chooses to go back
+	Then they are presented with the Catalogue Solutions available from their chosen Supplier
+	And the User's selected Catalogue Solution is selected


### PR DESCRIPTION
[AB#7547](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7547)
There's a bit of manual testing needed for this one, I don't see a clean way of dealing with scenarios 2 & 3, and there's the check on the scenario 5 go back to make sure the correct radio is still selected