### PR TITLE
7840: Edit a single Catalogue Solution - Flat List Price - Variable (on-demand)

### DIFF
--- a/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
@@ -594,12 +594,12 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 			return Driver.FindElements(Pages.OrderForm.OrderDate).Count == 1;
 		}
 
-		public void EnterProposedDate(DateTime dateTime)
+		public void EnterProposedDate(string year, string month, string day)
 		{
 			Wait.Until(d => d.FindElements(Pages.OrderForm.OrderDateDay).Count == 1);
-			Driver.FindElement(Pages.OrderForm.OrderDateDay).SendKeys(dateTime.Day.ToString());
-			Driver.FindElement(Pages.OrderForm.OrderDateMonth).SendKeys(dateTime.Month.ToString());
-			Driver.FindElement(Pages.OrderForm.OrderDateYear).SendKeys(dateTime.Year.ToString());
+			Driver.FindElement(Pages.OrderForm.OrderDateDay).SendKeys(day);
+			Driver.FindElement(Pages.OrderForm.OrderDateMonth).SendKeys(month);
+			Driver.FindElement(Pages.OrderForm.OrderDateYear).SendKeys(year);
 		}
 
 		public bool EstimationPeriodIsDisplayed()

--- a/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
@@ -565,6 +565,13 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 			return Driver.FindElement(Pages.OrderForm.PriceInput).GetAttribute("value");
 		}
 
+		public void EnterPriceInputValue(string value)
+		{
+			Wait.Until(d => d.FindElements(Pages.OrderForm.PriceInput).Count == 1);
+			Driver.FindElement(Pages.OrderForm.PriceInput).Clear();
+			Driver.FindElement(Pages.OrderForm.PriceInput).SendKeys(value);
+		}
+
 		public bool OrderUnitIsDisplayed()
 		{
 			return Driver.FindElements(Pages.OrderForm.OrderUnit).Count == 1;
@@ -574,12 +581,27 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 		{
 			return Driver.FindElements(Pages.OrderForm.Quantity).Count == 1;
 		}
-		
+
+		public void EnterQuantity(string value)
+		{
+			Wait.Until(d => d.FindElements(Pages.OrderForm.Quantity).Count == 1);
+			Driver.FindElement(Pages.OrderForm.Quantity).Clear();
+			Driver.FindElement(Pages.OrderForm.Quantity).SendKeys(value);
+		}
+
 		public bool ProposedDateInputIsDisplayed()
 		{
 			return Driver.FindElements(Pages.OrderForm.OrderDate).Count == 1;
 		}
-		
+
+		public void EnterProposedDate(DateTime dateTime)
+		{
+			Wait.Until(d => d.FindElements(Pages.OrderForm.OrderDateDay).Count == 1);
+			Driver.FindElement(Pages.OrderForm.OrderDateDay).SendKeys(dateTime.Day.ToString());
+			Driver.FindElement(Pages.OrderForm.OrderDateMonth).SendKeys(dateTime.Month.ToString());
+			Driver.FindElement(Pages.OrderForm.OrderDateYear).SendKeys(dateTime.Year.ToString());
+		}
+
 		public bool EstimationPeriodIsDisplayed()
 		{
 			return Driver.FindElements(Pages.OrderForm.EstimationPeriod).Count == 1;

--- a/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
@@ -594,12 +594,20 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 			return Driver.FindElements(Pages.OrderForm.OrderDate).Count == 1;
 		}
 
+		public void EnterProposedDate(DateTime value)
+		{
+			EnterProposedDate(value.Year.ToString(), value.Month.ToString(), value.Day.ToString());
+		}
+
 		public void EnterProposedDate(string year, string month, string day)
 		{
 			Wait.Until(d => d.FindElements(Pages.OrderForm.OrderDateDay).Count == 1);
-			Driver.FindElement(Pages.OrderForm.OrderDateDay).SendKeys(day);
-			Driver.FindElement(Pages.OrderForm.OrderDateMonth).SendKeys(month);
-			Driver.FindElement(Pages.OrderForm.OrderDateYear).SendKeys(year);
+			Driver.FindElement(Pages.OrderForm.OrderDateDay).Clear();
+			Driver.FindElement(Pages.OrderForm.OrderDateMonth).Clear();
+			Driver.FindElement(Pages.OrderForm.OrderDateYear).Clear();
+			Driver.EnterTextViaJs(Wait, Pages.OrderForm.OrderDateDay, day);
+			Driver.EnterTextViaJs(Wait, Pages.OrderForm.OrderDateMonth, month);
+			Driver.EnterTextViaJs(Wait, Pages.OrderForm.OrderDateYear, year);
 		}
 
 		public bool EstimationPeriodIsDisplayed()

--- a/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Actions/Pages/OrderForm.cs
@@ -73,9 +73,9 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 			return Driver.FindElement(Pages.OrderForm.PageTitle).Text.Split("Order")[1].Trim();
 		}
 
-		public bool CallOffIdDisplayedInPageTitle(string callOffAgreementId)
+		public bool TextDisplayedInPageTitle(string expectedValue)
 		{
-			return Driver.FindElement(Pages.OrderForm.PageTitle).Text.Contains(callOffAgreementId);
+			return Driver.FindElement(Pages.OrderForm.PageTitle).Text.Contains(expectedValue);
 		}
 
 		public bool TaskListDisplayed()
@@ -115,6 +115,11 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 		public bool DeleteOrderButtonIsDisabled()
 		{
 			return Driver.FindElement(Pages.OrderForm.DeleteOrderButton).FindElement(By.TagName("a")).GetAttribute("aria-disabled") != null;
+		}
+
+		public bool DeleteSolutionButtonIsDisabled()
+		{
+			return Driver.FindElement(Pages.Common.DeleteButton).GetAttribute("aria-disabled") != null;
 		}
 
 		public bool PreviewOrderButtonIsDisabled()
@@ -298,6 +303,11 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 		public void ClickEditCatalogueSolutions()
 		{
 			Driver.FindElement(Pages.OrderForm.EditCatalogueSolutions).Click();
+		}
+
+		public bool SaveButtonDisplayed()
+		{
+			return Driver.FindElements(Pages.Common.SaveButton).Count == 1;
 		}
 
 		public void ClickSaveButton()
@@ -543,6 +553,36 @@ namespace OrderFormAcceptanceTests.Actions.Pages
 			var element = Driver.FindElements(Pages.Common.RadioButton)[index];
 			element.Click();
 			return element.GetAttribute("value");
+		}
+
+		public bool PriceInputIsDisplayed()
+		{
+			return Driver.FindElements(Pages.OrderForm.PriceInput).Count == 1;
+		}
+
+		public string GetPriceInputValue()
+		{
+			return Driver.FindElement(Pages.OrderForm.PriceInput).GetAttribute("value");
+		}
+
+		public bool OrderUnitIsDisplayed()
+		{
+			return Driver.FindElements(Pages.OrderForm.OrderUnit).Count == 1;
+		}
+			
+		public bool QuantityInputIsDisplayed()
+		{
+			return Driver.FindElements(Pages.OrderForm.Quantity).Count == 1;
+		}
+		
+		public bool ProposedDateInputIsDisplayed()
+		{
+			return Driver.FindElements(Pages.OrderForm.OrderDate).Count == 1;
+		}
+		
+		public bool EstimationPeriodIsDisplayed()
+		{
+			return Driver.FindElements(Pages.OrderForm.EstimationPeriod).Count == 1;
 		}
 	}
 }

--- a/src/OrderFormAcceptanceTests.Objects/Pages/Common.cs
+++ b/src/OrderFormAcceptanceTests.Objects/Pages/Common.cs
@@ -13,6 +13,7 @@ namespace OrderFormAcceptanceTests.Objects.Pages
 		public By LoggedInDisplayName => CustomBy.DataTestId("logged-in-text");
 		public By SaveButton => CustomBy.DataTestId("save-button", "button");
 		public By ContinueButton => CustomBy.DataTestId("continue-button", "button");
+		public By DeleteButton => CustomBy.DataTestId("delete-button", "a");
 		public By TextArea => By.TagName("textarea");
 		public By TextField => By.ClassName("nhsuk-input");
 		public By Checkbox => By.ClassName("nhsuk-checkboxes__input");

--- a/src/OrderFormAcceptanceTests.Objects/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Objects/Pages/OrderForm.cs
@@ -48,6 +48,9 @@ namespace OrderFormAcceptanceTests.Objects.Pages
 		public By OrderUnit => CustomBy.DataTestId("order-unit-id");
 		public By Quantity => By.Id("quantity");
 		public By OrderDate => CustomBy.DataTestId("date-field-input");
+		public By OrderDateDay => By.Id("plannedDeliveryDate-day");
+		public By OrderDateMonth => By.Id("plannedDeliveryDate-month");
+		public By OrderDateYear => By.Id("plannedDeliveryDate-year");
 		public By EstimationPeriod => CustomBy.DataTestId("question-selectEstimationPeriod");
 
 

--- a/src/OrderFormAcceptanceTests.Objects/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Objects/Pages/OrderForm.cs
@@ -44,5 +44,12 @@ namespace OrderFormAcceptanceTests.Objects.Pages
 		public By ServiceRecipientOdsCode => By.CssSelector(".bc-c-service-recipients-table__ods");
 		public By AddSolution => CustomBy.DataTestId("add-orderItem-button", "a");
 		public By NoSolutionsAdded => CustomBy.DataTestId("no-added-solutions");
+		public By PriceInput => By.Id("price-input-id");
+		public By OrderUnit => CustomBy.DataTestId("order-unit-id");
+		public By Quantity => By.Id("quantity");
+		public By OrderDate => CustomBy.DataTestId("date-field-input");
+		public By EstimationPeriod => CustomBy.DataTestId("question-selectEstimationPeriod");
+
+
 	}
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CallOffOrderingParty.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CallOffOrderingParty.cs
@@ -54,7 +54,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         [Then(@"the Call Off Agreement ID is displayed in the page title")]
         public void ThenTheCallOffAgreementIDIsDisplayedInThePageTitle()
         {
-            Test.Pages.OrderForm.CallOffIdDisplayedInPageTitle(((Order)Context["CreatedOrder"]).OrderId).Should().BeTrue();
+            Test.Pages.OrderForm.TextDisplayedInPageTitle(((Order)Context["CreatedOrder"]).OrderId).Should().BeTrue();
         }
 
         [Given(@"the user is managing the Call Off Ordering Party section")]

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -260,5 +260,14 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrderForm.SaveButtonDisplayed().Should().BeTrue();            
         }
 
+
+        [Given(@"the User is presented with the Catalogue Solution edit form")]
+        public void GivenTheUserIsPresentedWithTheCatalogueSolutionEditForm()
+        {
+            GivenTheUserIsPresentedWithTheServiceRecipientsSavedInTheOrder();
+            GivenAServiceRecipientIsSelected();
+            new CommonSteps(Test, Context).WhenTheyChooseToContinue();
+            ThenTheyArePresentedWithTheCatalogueSolutionEditForm();
+        }
     }
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -273,8 +273,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         [Given(@"the proposed date is an invalid date")]
         public void GivenTheProposedDateIsAnInvalidDate()
         {
-            var thirtiethOfFebNextYar = new DateTime(new DateTime().AddYears(1).Year, 02, 30);
-            Test.Pages.OrderForm.EnterProposedDate(thirtiethOfFebNextYar);
+            Test.Pages.OrderForm.EnterProposedDate(DateTime.Now.AddYears(1).Year.ToString(), "02", "30");
         }
 
         [Given(@"the price has 4 decimal places")]

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using TechTalk.SpecFlow;
 
 namespace OrderFormAcceptanceTests.Steps.Steps
@@ -64,7 +65,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             ThenTheUserIsAbleToManageTheCatalogueSolutionsSection();
         }
 
-        [Then(@"the Catalogue Solution dashboard is presented")]
+        [StepDefinition(@"the Catalogue Solution dashboard is presented")]
         public void ThenTheCatalogueSolutionDashboardIsPresented()
         {
             Test.Pages.OrderForm.EditNamedSectionPageDisplayed("Catalogue Solution").Should().BeTrue();
@@ -332,6 +333,14 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         {
             Test.Pages.OrderForm.EnterPriceInputValue("79,228,162,514,264,337,593,543,950,335.50");
         }
+
+        [Then(@"the price is displayed to two decimal places")]
+        public void ThenThePriceIsDisplayedToTwoDecimalPlaces()
+        {
+            var actualPrice = Test.Pages.OrderForm.GetPriceInputValue();
+            Regex.Match(actualPrice, @"^[0-9]*\.[0-9]{2,3}$").Success.Should().BeTrue();
+        }
+
 
         [Given(@"the quantity contains characters")]
         public void GivenTheQuantityContainsCharacters()

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -269,5 +269,49 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             new CommonSteps(Test, Context).WhenTheyChooseToContinue();
             ThenTheyArePresentedWithTheCatalogueSolutionEditForm();
         }
+
+        [Given(@"the proposed date is an invalid date")]
+        public void GivenTheProposedDateIsAnInvalidDate()
+        {
+            var thirtiethOfFebNextYar = new DateTime(new DateTime().AddYears(1).Year, 02, 30);
+            Test.Pages.OrderForm.EnterProposedDate(thirtiethOfFebNextYar);
+        }
+
+        [Given(@"the price has 4 decimal places")]
+        public void GivenThePriceHasDecimalPlaces()
+        {
+            Test.Pages.OrderForm.EnterPriceInputValue("1.1234");
+        }
+
+        [Given(@"the price is negative")]
+        public void GivenThePriceIsNegative()
+        {
+            Test.Pages.OrderForm.EnterPriceInputValue("-12.398");
+        }
+
+        [Given(@"the price contains characters")]
+        public void GivenThePriceContainsCharacters()
+        {
+            Test.Pages.OrderForm.EnterPriceInputValue("1point35");
+        }
+
+        [Given(@"the quantity contains characters")]
+        public void GivenTheQuantityContainsCharacters()
+        {
+            Test.Pages.OrderForm.EnterQuantity("seven");
+        }
+
+        [Given(@"the quanitity is a decimal")]
+        public void GivenTheQuanitityIsADecimal()
+        {
+            Test.Pages.OrderForm.EnterQuantity("3.142");
+        }
+
+        [Given(@"the quantity is negative")]
+        public void GivenTheQuantityIsNegative()
+        {
+            Test.Pages.OrderForm.EnterQuantity("-100");
+        }
+
     }
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -163,6 +163,13 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrderForm.ClickRadioButton();
         }
 
+        [Given(@"a Service Recipient is selected")]
+        public void GivenAServiceRecipientIsSelected()
+        {
+            var odsCode = Test.Pages.OrderForm.ClickRadioButton();
+            Context.Add("ChosenOdsCode", odsCode);
+        }
+
         [Given(@"the User is presented with the Service Recipients saved in the Order")]
         public void GivenTheUserIsPresentedWithTheServiceRecipientsSavedInTheOrder()
         {
@@ -179,5 +186,79 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrderForm.ErrorMessagesDisplayed().Should().BeTrue();
             Test.Pages.OrderForm.ClickOnErrorLink().Should().ContainEquivalentOf("selectRecipient");
         }
+
+        [Then(@"they are presented with the Catalogue Solution edit form")]
+        public void ThenTheyArePresentedWithTheCatalogueSolutionEditForm()
+        {
+            Test.Pages.OrderForm.EditNamedSectionPageDisplayed("information for").Should().BeTrue();
+        }
+
+        [Then(@"the name of the selected Catalogue Solution is displayed on the Catalogue Solution edit form")]
+        public void ThenTheNameOfTheSelectedCatalogueSolutionIsDisplayedOnTheCatalogueSolutionEditForm()
+        {
+            var SolutionId = (string)Context["ChosenSolutionId"];
+            var query = "Select Name FROM [dbo].[CatalogueItem] where CatalogueItemId=@SolutionId";
+            var expectedSolutionName = SqlExecutor.Execute<string>(Test.BapiConnectionString, query, new { SolutionId }).Single();
+            Test.Pages.OrderForm.TextDisplayedInPageTitle(expectedSolutionName).Should().BeTrue();
+        }
+
+        [Then(@"the selected Service Recipient with their ODS code is displayed on the Catalogue Solution edit form")]
+        public void ThenTheSelectedServiceRecipientWithTheirODSCodeIsDisplayedOnTheCatalogueSolutionEditForm()
+        {
+            var ChosenOdsCode = (string)Context["ChosenOdsCode"];
+            var query = "Select Name FROM [dbo].[Organisations] where OdsCode=@ChosenOdsCode";
+            var expectedOrganisationName = SqlExecutor.Execute<string>(Test.IsapiConnectionString, query, new { ChosenOdsCode }).Single();
+            var expectedFormattedValue = string.Format("{0} ({1})", expectedOrganisationName, ChosenOdsCode);
+            Test.Pages.OrderForm.TextDisplayedInPageTitle(expectedFormattedValue).Should().BeTrue();
+        }
+
+        [Then(@"the Catalogue Solution edit form contains an input for the price")]
+        public void ThenTheCatalogueSolutionEditFormContainsAnInputForThePrice()
+        {
+            Test.Pages.OrderForm.PriceInputIsDisplayed().Should().BeTrue();
+        }
+
+        [Then(@"the price input is autopopulated with the list price for the flat list price selected")]
+        public void ThenThePriceInputIsAutopopulatedWithTheListPriceForTheFlatListPriceSelected()
+        {
+            Test.Pages.OrderForm.GetPriceInputValue().Should().NotBeNullOrEmpty();            
+        }
+
+        [Then(@"the item on the Catalogue Solution edit form contains a unit of order")]
+        public void ThenTheItemOnTheCatalogueSolutionEditFormContainsAUnitOfOrder()
+        {
+            Test.Pages.OrderForm.OrderUnitIsDisplayed().Should().BeTrue();
+        }
+
+        [Then(@"the item on the Catalogue Solution edit form contains an input for the quantity")]
+        public void ThenTheItemOnTheCatalogueSolutionEditFormContainsAnInputForTheQuantity()
+        {
+            Test.Pages.OrderForm.QuantityInputIsDisplayed().Should().BeTrue();
+        }
+
+        [Then(@"the item on the Catalogue Solution edit form contains an input for date")]
+        public void ThenTheItemOnTheCatalogueSolutionEditFormContainsAnInputForDate()
+        {
+            Test.Pages.OrderForm.ProposedDateInputIsDisplayed().Should().BeTrue();
+        }
+
+        [Then(@"the item on the Catalogue Solution edit form contains a selection for the quantity estimation period")]
+        public void ThenTheItemOnTheCatalogueSolutionEditFormContainsASelectionForTheQuantityEstimationPeriod()
+        {
+            Test.Pages.OrderForm.EstimationPeriodIsDisplayed().Should().BeTrue();
+        }
+
+        [Then(@"the delete button is disabled")]
+        public void ThenTheDeleteButtonIsDisabled()
+        {
+            Test.Pages.OrderForm.DeleteSolutionButtonIsDisabled().Should().BeTrue();
+        }
+        
+        [Then(@"the save button is enabled")]
+        public void ThenTheSaveButtonIsEnabled()
+        {
+            Test.Pages.OrderForm.SaveButtonDisplayed().Should().BeTrue();            
+        }
+
     }
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using Bogus;
+using FluentAssertions;
 using OrderFormAcceptanceTests.Steps.Utils;
 using OrderFormAcceptanceTests.TestData;
 using OrderFormAcceptanceTests.TestData.Utils;
@@ -276,6 +277,38 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrderForm.EnterProposedDate(DateTime.Now.AddYears(1).Year.ToString(), "02", "30");
         }
 
+        [Given(@"the User enters a Delivery Date that is equal to 183 weeks after the Commencement Date")]
+        public void GivenTheUserEntersADeliveryDateThatIsEqualToWeeksAfterTheCommencementDate()
+        {
+            var order = (Order)Context["CreatedOrder"];
+            var deliveryDate = order.CommencementDate.Value.AddDays(7 * 183);
+            Test.Pages.OrderForm.EnterProposedDate(deliveryDate);
+        }
+
+        [Given(@"the User enters a Delivery Date that is less than 183 weeks after the Commencement Date")]
+        public void GivenTheUserEntersADeliveryDateThatIsLessThanWeeksAfterTheCommencementDate()
+        {
+            var order = (Order)Context["CreatedOrder"];
+            var deliveryDate = order.CommencementDate.Value.AddDays(7 * 182);
+            Test.Pages.OrderForm.EnterProposedDate(deliveryDate);
+        }
+
+        [Given(@"the User enters a Delivery Date that is more than 183 weeks after the Commencement Date")]
+        public void GivenTheUserEntersADeliveryDateThatIsMoreThanWeeksAfterTheCommencementDate()
+        {
+            var order = (Order)Context["CreatedOrder"];
+            var deliveryDate = order.CommencementDate.Value.AddDays((7 * 183) + 1);
+            Test.Pages.OrderForm.EnterProposedDate(deliveryDate);
+        }
+
+        [Given(@"the User enters a Delivery Date that is before the Commencement Date")]
+        public void GivenTheUserEntersADeliveryDateThatIsBeforeTheCommencementDate()
+        {
+            var order = (Order)Context["CreatedOrder"];
+            var deliveryDate = order.CommencementDate.Value.AddDays(-1);
+            Test.Pages.OrderForm.EnterProposedDate(deliveryDate);
+        }
+
         [Given(@"the price has 4 decimal places")]
         public void GivenThePriceHasDecimalPlaces()
         {
@@ -294,6 +327,12 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrderForm.EnterPriceInputValue("1point35");
         }
 
+        [Given(@"the price is over the max value")]
+        public void GivenThePriceIsOverTheMaxValue()
+        {
+            Test.Pages.OrderForm.EnterPriceInputValue("79,228,162,514,264,337,593,543,950,335.50");
+        }
+
         [Given(@"the quantity contains characters")]
         public void GivenTheQuantityContainsCharacters()
         {
@@ -310,6 +349,24 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         public void GivenTheQuantityIsNegative()
         {
             Test.Pages.OrderForm.EnterQuantity("-100");
+        }
+
+        [Given(@"the quantity is over the max length")]
+        public void GivenTheQuantityIsOverTheMaxLength()
+        {
+            Test.Pages.OrderForm.EnterQuantity("2,147,483,648");
+        }
+
+        [Given(@"fills in the Catalogue Solution edit form with valid data")]
+        public void GivenFillsInTheCatalogueSolutionEditFormWithValidData()
+        {
+            var order = (Order)Context["CreatedOrder"];
+            var deliveryDate = order.CommencementDate.Value;
+            Test.Pages.OrderForm.EnterProposedDate(deliveryDate);
+
+            var f = new Faker();
+            Test.Pages.OrderForm.EnterQuantity(f.Random.Number(min:1).ToString());
+            Test.Pages.OrderForm.EnterPriceInputValue(f.Finance.Amount().ToString());
         }
 
     }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
@@ -55,7 +55,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
 
         [Then(@".* section is not saved")]
         [Then(@"the Catalogue Solution is not saved")]
-        [Then(@"the Catalogue Solution is saved")]
+        [StepDefinition(@"the Catalogue Solution is saved")]
         [Given(@"no Supplier is selected")]
         [Then("the Commencement Date information is not saved")]
         [Given(@"the Call Off Ordering Party is not selected")]

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
@@ -54,6 +54,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         }
 
         [Then(@".* section is not saved")]
+        [Then(@"the Catalogue Solution is not saved")]
         [Given(@"no Supplier is selected")]
         [Then("the Commencement Date information is not saved")]
         [Given(@"the Call Off Ordering Party is not selected")]

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CommonSteps.cs
@@ -55,6 +55,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
 
         [Then(@".* section is not saved")]
         [Then(@"the Catalogue Solution is not saved")]
+        [Then(@"the Catalogue Solution is saved")]
         [Given(@"no Supplier is selected")]
         [Then("the Commencement Date information is not saved")]
         [Given(@"the Call Off Ordering Party is not selected")]

--- a/src/OrderFormAcceptanceTests.Steps/Steps/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/OrderForm.cs
@@ -68,7 +68,7 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             ThenTheUserIsAbleToManageTheOrderDescriptionSection();
         }
 
-        [When(@"the User chooses to save")]
+        [StepDefinition(@"the User chooses to save")]
         [Given(@"the validation has been triggered")]
         public void WhenTheUserChoosesToSave()
         {

--- a/src/OrderFormAcceptanceTests.Steps/Utils/EnvironmentVariables.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Utils/EnvironmentVariables.cs
@@ -63,6 +63,15 @@ namespace OrderFormAcceptanceTests.Steps.Utils
             return string.Format(ConnectionString.GPitFutures, serverUrl, databaseName, dbUser, dbPassword);
         }
 
+        internal static string IsapiDbConnectionString()
+        {
+            var (serverUrl, databaseName, dbUser, dbPassword) = DbConnectionDetails();
+
+            databaseName = Environment.GetEnvironmentVariable("ISAPIDATABASENAME") ?? "CatalogueUsers";
+
+            return string.Format(ConnectionString.GPitFutures, serverUrl, databaseName, dbUser, dbPassword);
+        }
+
         private static string JsonConfigValues(string section, string defaultValue)
         {
             var path = Path.Combine(Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory), "Utils",

--- a/src/OrderFormAcceptanceTests.Steps/Utils/UITest.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Utils/UITest.cs
@@ -8,6 +8,7 @@ namespace OrderFormAcceptanceTests.Steps.Utils
     {
         internal string ConnectionString;
         internal string BapiConnectionString;
+        internal string IsapiConnectionString;
         internal IWebDriver Driver;
         internal PageActionCollection Pages;
         internal readonly string Url;
@@ -16,6 +17,7 @@ namespace OrderFormAcceptanceTests.Steps.Utils
         {
             ConnectionString = EnvironmentVariables.DbConnectionString();
             BapiConnectionString = EnvironmentVariables.BapiDbConnectionString();
+            IsapiConnectionString = EnvironmentVariables.IsapiDbConnectionString();
 
             Driver = new BrowserFactory().Driver;
             Pages = new PageActions(Driver).PageActionCollection;

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -110,3 +110,119 @@ Scenario: Catalogue Solutions - Go back from select a service recipient
 	Given the User is presented with the Service Recipients saved in the Order
 	When the User chooses to go back
 	Then all the available prices for that Catalogue Solution are presented
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price with variable order type selected
+	Given the User is presented with the Service Recipients saved in the Order
+	And a Service Recipient is selected
+	When they choose to continue
+	Then they are presented with the Catalogue Solution edit form
+	And the name of the selected Catalogue Solution is displayed on the Catalogue Solution edit form
+	And the selected Service Recipient with their ODS code is displayed on the Catalogue Solution edit form
+	And the Catalogue Solution edit form contains an input for the price
+	And the item on the Catalogue Solution edit form contains a unit of order
+	And the item on the Catalogue Solution edit form contains an input for the quantity
+	And the item on the Catalogue Solution edit form contains an input for date
+	And the item on the Catalogue Solution edit form contains a selection for the quantity estimation period 
+	And the price input is autopopulated with the list price for the flat list price selected
+	And the delete button is disabled
+	And the save button is enabled
+	@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Mandatory data missing
+	Given mandatory data are missing 
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
+	@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid
+Given the User has entered data into a field
+And the data type is not valid
+When they choose to save
+Then the Catalogue Solution is not saved
+And the reason is displayed
+
+#Additional Information:
+#Date must be a valid date
+#Price must be to no more than 3 decimal places
+#Quantity must be an integer
+#Quantity cannot be negative
+#Price cannot be negative
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data exceeds the maximum length
+Given the User has entered data into a field
+And it exceeds the maximum length
+When they choose to save 
+Then the Catalogue Solution is not saved 
+And the reason is displayed
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Validation Error Message Anchors
+Given validation has been triggered
+When the user selects an error link in the Error Summary
+Then they will be navigated to the relevant part of the page
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Delivery date is equal to 183 weeks after commencement date
+Given there is a Commencement Date
+And the Delivery Date cannot be later than 183 weeks after the Commencement Date
+When the User enters a Delivery Date that is equal to 183 weeks after the Commencement Date
+Then the Delivery Date is valid
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Delivery date is less than 183 weeks after commencement date
+Given there is a Commencement Date
+And the Delivery Date cannot be later than 183 weeks after the Commencement Date
+When the User enters a Delivery Date that is less than 183 weeks after the Commencement Date
+Then the Delivery Date is valid
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Delivery date is more than 183 weeks after commencement date
+Given there is a Commencement Date
+And the Delivery Date cannot be later than 183 weeks after the Commencement Date
+When the User enters a Delivery Date that is more than 183 weeks after the Commencement Date
+Then the Delivery Date is invalid
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Delivery Date cannot be before commencement date
+Given there is a Commencement Date
+And the Delivery Date cannot be before the Commencement Date
+When the User enters a Delivery Date that is before the Commencement Date
+Then the Delivery Date is invalid
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price All data are valid
+Given all the data are valid
+When the User saves the Catalogue Solution
+Then the Catalogue Solution is saved
+And the content validation status of the Catalogue Solution is Complete
+And the section content validation status of Complete is displayed on the Orders dashboard
+And the delete button is enabled
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price values populated after editing and saving
+Given that the User has amended a price
+And entered a quantity
+And selected a period
+And saved the Solution
+And entered a date
+And navigated away from the Catalogue Solution
+When the User re-visits the Catalogue Solution
+Then the price value will be populated with the value that was saved by the User
+And the quantity value will be populated with the value that was saved by the User
+And the period selection will be the value that was selected by the User
+And the date value will be the value that was saved by the User
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Price is displayed to a minimum of 2 decimal places 
+Given that a Price is to less than two decimal places
+When it is displayed
+Then it is displayed to two decimal places
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Go back before save
+Given the edit Catalogue Solution form for flat list price with variable (patient numbers) order type is presented
+And the User hasn't saved the Catalogue Solution
+When the User chooses to go back
+Then the select service recipient page is presented
+And the User's selected service recipient is selected
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Go back post save
+Given the edit Catalogue Solution form for flat list price with variable (patient numbers) order type is presented
+And the User has saved the Catalogue Solution
+When the User chooses to go back
+Then the Catalogue Solution Dashboard is displayed
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Select quantity period
+Given the User can select a quantity period
+When estimating quantity
+Then the User can choose the quantity period as Per Year or Per Month

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -183,41 +183,58 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
 @ignore
-Scenario: Catalogue Solutions - edit price screen - Flat price Data exceeds the maximum length
-Given the User has entered data into a field
-And it exceeds the maximum length
-When the User chooses to save
-Then the Catalogue Solution is not saved 
-And the reason is displayed
+Scenario: Catalogue Solutions - edit price screen - Flat price - quantity exceeds the maximum length
+	Given the User is presented with the Catalogue Solution edit form
+	And the quantity is over the max length
+	When the User chooses to save
+	Then the Catalogue Solution is not saved 
+	And the reason is displayed
+	@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price - price exceeds the maximum value
+	Given the User is presented with the Catalogue Solution edit form
+	And the price is over the max value
+	When the User chooses to save
+	Then the Catalogue Solution is not saved 
+	And the reason is displayed
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Validation Error Message Anchors
-Given validation has been triggered
-When the user selects an error link in the Error Summary
-Then they will be navigated to the relevant part of the page
+	Given the User is presented with the Catalogue Solution edit form
+	And mandatory data are missing
+	And the validation has been triggered
+	When the user selects an error link in the Error Summary
+	Then they will be navigated to the relevant part of the page
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Delivery date is equal to 183 weeks after commencement date
-Given there is a Commencement Date
-And the Delivery Date cannot be later than 183 weeks after the Commencement Date
-When the User enters a Delivery Date that is equal to 183 weeks after the Commencement Date
-Then the Delivery Date is valid
+	Given the User is presented with the Catalogue Solution edit form
+	And fills in the Catalogue Solution edit form with valid data
+	And the User enters a Delivery Date that is equal to 183 weeks after the Commencement Date
+	When the User chooses to save
+	Then the Catalogue Solution is saved
+	And the Catalogue Solution dashboard is presented
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Delivery date is less than 183 weeks after commencement date
-Given there is a Commencement Date
-And the Delivery Date cannot be later than 183 weeks after the Commencement Date
-When the User enters a Delivery Date that is less than 183 weeks after the Commencement Date
-Then the Delivery Date is valid
+	Given the User is presented with the Catalogue Solution edit form
+	And fills in the Catalogue Solution edit form with valid data
+	And the User enters a Delivery Date that is less than 183 weeks after the Commencement Date
+	When the User chooses to save
+	Then the Catalogue Solution is saved
+	And the Catalogue Solution dashboard is presented
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Delivery date is more than 183 weeks after commencement date
-Given there is a Commencement Date
-And the Delivery Date cannot be later than 183 weeks after the Commencement Date
-When the User enters a Delivery Date that is more than 183 weeks after the Commencement Date
-Then the Delivery Date is invalid
+	Given the User is presented with the Catalogue Solution edit form
+	And fills in the Catalogue Solution edit form with valid data
+	And the User enters a Delivery Date that is more than 183 weeks after the Commencement Date
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Delivery Date cannot be before commencement date
-Given there is a Commencement Date
-And the Delivery Date cannot be before the Commencement Date
-When the User enters a Delivery Date that is before the Commencement Date
-Then the Delivery Date is invalid
+	Given the User is presented with the Catalogue Solution edit form
+	And fills in the Catalogue Solution edit form with valid data
+	And the User enters a Delivery Date that is before the Commencement Date
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price All data are valid
 Given all the data are valid

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -128,7 +128,8 @@ Scenario: Catalogue Solutions - edit price screen - Flat price with variable ord
 	And the save button is enabled
 	@ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Mandatory data missing
-	Given mandatory data are missing 
+	Given the User is presented with the Catalogue Solution edit form
+	And mandatory data are missing 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -134,24 +134,66 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Mandatory data mi
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
 	@ignore
-Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid
-Given the User has entered data into a field
-And the data type is not valid
-When they choose to save
-Then the Catalogue Solution is not saved
-And the reason is displayed
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - invalid date
+	Given the User is presented with the Catalogue Solution edit form
+	And the proposed date is an invalid date
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
 
-#Additional Information:
-#Date must be a valid date
-#Price must be to no more than 3 decimal places
-#Quantity must be an integer
-#Quantity cannot be negative
-#Price cannot be negative
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - price with 4 decimal place
+	Given the User is presented with the Catalogue Solution edit form
+	And the price has 4 decimal places
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
+
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - price is negative
+	Given the User is presented with the Catalogue Solution edit form
+	And the price is negative
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
+
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - price does not allow characters
+	Given the User is presented with the Catalogue Solution edit form
+	And the price contains characters
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
+
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - quantity does not allow characters
+	Given the User is presented with the Catalogue Solution edit form
+	And the quantity contains characters
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
+
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - quantity does not allow decimals
+	Given the User is presented with the Catalogue Solution edit form
+	And the quanitity is a decimal
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
+
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - quantity can not be negative
+	Given the User is presented with the Catalogue Solution edit form
+	And the quantity is negative
+	When the User chooses to save
+	Then the Catalogue Solution is not saved
+	And the reason is displayed
+
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data exceeds the maximum length
 Given the User has entered data into a field
 And it exceeds the maximum length
-When they choose to save 
+When the User chooses to save
 Then the Catalogue Solution is not saved 
 And the reason is displayed
 @ignore

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -122,7 +122,7 @@ Scenario: Catalogue Solutions - edit price screen - Flat price with variable ord
 	And the item on the Catalogue Solution edit form contains a unit of order
 	And the item on the Catalogue Solution edit form contains an input for the quantity
 	And the item on the Catalogue Solution edit form contains an input for date
-	And the item on the Catalogue Solution edit form contains a selection for the quantity estimation period 
+	And the item on the Catalogue Solution edit form contains a selection for the quantity estimation period
 	And the price input is autopopulated with the list price for the flat list price selected
 	And the delete button is disabled
 	And the save button is enabled
@@ -237,12 +237,32 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Delivery Date can
 	And the reason is displayed
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price All data are valid
-Given all the data are valid
-When the User saves the Catalogue Solution
-Then the Catalogue Solution is saved
-And the content validation status of the Catalogue Solution is Complete
-And the section content validation status of Complete is displayed on the Orders dashboard
-And the delete button is enabled
+	Given the User is presented with the Catalogue Solution edit form
+	And fills in the Catalogue Solution edit form with valid data
+	When the User chooses to save
+	Then the Catalogue Solution is saved
+	And the Catalogue Solution dashboard is presented
+@ignore
+Scenario: Catalogue Solutions - edit price screen - section complete
+	Given the User is presented with the Catalogue Solution edit form
+	And fills in the Catalogue Solution edit form with valid data
+	And the User chooses to save
+	And the Catalogue Solution is saved
+	And the Catalogue Solution dashboard is presented
+	When the User chooses to go back
+	Then the Order dashboard is presented
+	And the content validation status of the catalogue-solutions section is complete
+
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Price is displayed to a minimum of 2 decimal places 
+	Given the User is presented with the Catalogue Solution edit form
+	Then the price is displayed to two decimal places
+@ignore
+Scenario: Catalogue Solutions - edit price screen - Flat price Go back before save
+	Given the User is presented with the Catalogue Solution edit form
+	When the User chooses to go back
+	Then they are presented with the Service Recipients saved in the Order
+
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price values populated after editing and saving
 Given that the User has amended a price
@@ -256,26 +276,11 @@ Then the price value will be populated with the value that was saved by the User
 And the quantity value will be populated with the value that was saved by the User
 And the period selection will be the value that was selected by the User
 And the date value will be the value that was saved by the User
-@ignore
-Scenario: Catalogue Solutions - edit price screen - Flat price Price is displayed to a minimum of 2 decimal places 
-Given that a Price is to less than two decimal places
-When it is displayed
-Then it is displayed to two decimal places
-@ignore
-Scenario: Catalogue Solutions - edit price screen - Flat price Go back before save
-Given the edit Catalogue Solution form for flat list price with variable (patient numbers) order type is presented
-And the User hasn't saved the Catalogue Solution
-When the User chooses to go back
-Then the select service recipient page is presented
-And the User's selected service recipient is selected
+And the delete button is enabled
+
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Go back post save
 Given the edit Catalogue Solution form for flat list price with variable (patient numbers) order type is presented
 And the User has saved the Catalogue Solution
 When the User chooses to go back
 Then the Catalogue Solution Dashboard is displayed
-@ignore
-Scenario: Catalogue Solutions - edit price screen - Flat price Select quantity period
-Given the User can select a quantity period
-When estimating quantity
-Then the User can choose the quantity period as Per Year or Per Month

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/CatalogueSolutions.feature
@@ -140,7 +140,6 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
-
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - price with 4 decimal place
 	Given the User is presented with the Catalogue Solution edit form
@@ -148,7 +147,6 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
-
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - price is negative
 	Given the User is presented with the Catalogue Solution edit form
@@ -156,7 +154,6 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
-
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - price does not allow characters
 	Given the User is presented with the Catalogue Solution edit form
@@ -164,7 +161,6 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
-
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - quantity does not allow characters
 	Given the User is presented with the Catalogue Solution edit form
@@ -172,7 +168,6 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
-
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - quantity does not allow decimals
 	Given the User is presented with the Catalogue Solution edit form
@@ -180,7 +175,6 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
-
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not valid - quantity can not be negative
 	Given the User is presented with the Catalogue Solution edit form
@@ -188,7 +182,6 @@ Scenario: Catalogue Solutions - edit price screen - Flat price Data type is not 
 	When the User chooses to save
 	Then the Catalogue Solution is not saved
 	And the reason is displayed
-
 @ignore
 Scenario: Catalogue Solutions - edit price screen - Flat price Data exceeds the maximum length
 Given the User has entered data into a field


### PR DESCRIPTION
Tests tagged out, waiting for validation to go in
[AB#7726](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/7726)

I've not implemented 2 scenarios, as I think they're better dealt with under story 7252

- Scenario: Catalogue Solutions - edit price screen - Flat price values populated after editing and saving
- Scenario: Catalogue Solutions - edit price screen - Flat price Go back post save