### PR TITLE
8063: Remove the nominate organisation link on the Organisation's Orders dashboard

### DIFF
--- a/src/OrderFormAcceptanceTests.Actions/Pages/OrganisationsOrdersDashboard.cs
+++ b/src/OrderFormAcceptanceTests.Actions/Pages/OrganisationsOrdersDashboard.cs
@@ -83,10 +83,7 @@ namespace OrderFormAcceptanceTests.Actions.Pages
         {
             return Driver.FindElements(Pages.OrganisationsOrdersDashboard.SubmittedOrdersTable).Count == 1;
         }
-        public bool NominateProxyDisplayed()
-        {
-            return Driver.FindElements(Pages.OrganisationsOrdersDashboard.NominateProxy).Count == 1;
-        }
+
         public bool BackLinkDisplayed()
         {
             return Driver.FindElements(Pages.Common.BackLink).Count == 1;

--- a/src/OrderFormAcceptanceTests.Objects/Pages/OrganisationsOrdersDashboard.cs
+++ b/src/OrderFormAcceptanceTests.Objects/Pages/OrganisationsOrdersDashboard.cs
@@ -17,6 +17,5 @@ namespace OrderFormAcceptanceTests.Objects.Pages
 		public By GenericExistingOrderCreatedDate => By.CssSelector("[data-test-id$='-dateCreated']");
 		public By UnsubmittedOrdersTable => CustomBy.DataTestId("unsubmitted-orders-table");
 		public By SubmittedOrdersTable => CustomBy.DataTestId("submitted-orders-table");
-		public By NominateProxy => CustomBy.DataTestId("proxy-link", "a");
 	}
 }

--- a/src/OrderFormAcceptanceTests.Steps/Steps/OrganisationsOrdersDashboard.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/OrganisationsOrdersDashboard.cs
@@ -114,12 +114,6 @@ namespace OrderFormAcceptanceTests.Steps.Steps
             Test.Pages.OrganisationsOrdersDashboard.SubmittedOrdersTableDisplayed().Should().BeTrue();
         }
 
-        [Then(@"there is a control to nominate an organisation to buy on my behalf")]
-        public void ThenThereIsAControlToNominateAnOrganisationToBuyOnMyBehalf()
-        {
-            Test.Pages.OrganisationsOrdersDashboard.NominateProxyDisplayed().Should().BeTrue();
-        }
-
         [Then(@"there is a control to go back to the homepage")]
         public void ThenThereIsAControlToGoBackToTheHomepage()
         {

--- a/src/OrderFormAcceptanceTests.Tests/Features/ViewOrders.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ViewOrders.feature
@@ -14,7 +14,6 @@ Scenario: View Orders
 	And each item includes the date it was created
 	And there is a table titled Unsubmitted orders
 	And there is a table titled Submitted orders
-	And there is a control to nominate an organisation to buy on my behalf
 	And there is a control to go back to the homepage 
 	And there is a control to create a new order
 


### PR DESCRIPTION
[AB#8063](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/8063)
[AB#8315](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/8315)