### PR TITLE
4829: Display Order Form - Associated Services

### DIFF
--- a/src/OrderFormAcceptanceTests.Objects/Pages/OrderForm.cs
+++ b/src/OrderFormAcceptanceTests.Objects/Pages/OrderForm.cs
@@ -25,7 +25,7 @@ namespace OrderFormAcceptanceTests.Objects.Pages
 			return By.CssSelector(string.Format("[href$='{0}']", sectionHrefRoute));
 		}
 
-		public By OrderDescription => CustomBy.DataTestId("order-description");
+		public By OrderDescription => By.CssSelector("[data-test-id$=order-description");
 		public By OrganisationName => CustomBy.DataTestId("organisation-name");
 		public By OrganisationOdsCode => CustomBy.DataTestId("organisation-ods-code");
 		public Func<int, By> AddressLineX => (LineNumber) => By.CssSelector(string.Format("[data-test-id$=-address-{0}]", LineNumber.ToString()));

--- a/src/OrderFormAcceptanceTests.Steps/Steps/AdditionalServices.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/AdditionalServices.cs
@@ -15,11 +15,10 @@ namespace OrderFormAcceptanceTests.Steps.Steps
 		[Given(@"there are no Additional Services in the order")]
 		public void GivenThereAreNoAdditionalServicesInTheOrder()
 		{
-			var orderItem = (OrderItem)Context["CreatedAdditionalServiceOrderItem"];
-			orderItem.Should().BeNull();
-			var order = (Order)Context["CreatedOrder"];
+            Context.Should().NotContainKey("CreatedAdditionalServiceOrderItem");
+            var order = (Order)Context["CreatedOrder"];
 			var searchedOrderItem = new OrderItem().RetrieveByOrderId(Test.ConnectionString, order.OrderId, 2);
-			searchedOrderItem.Should().BeNull();
+            searchedOrderItem.Should().BeEmpty();
 		}
 
 		[Given(@"an Additional Service is added to the order")]

--- a/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
+++ b/src/OrderFormAcceptanceTests.Steps/Steps/CatalogueSolutions.cs
@@ -42,12 +42,12 @@ namespace OrderFormAcceptanceTests.Steps.Steps
         [Given(@"there is no Catalogue Solution in the order")]
         public void GivenThereIsNoCatalogueSolutionInTheOrder()
         {
-            var orderItem = (OrderItem)Context["CreatedOrderItem"];
-            orderItem.Should().BeNull();
+
+            Context.Should().NotContainKey("CreatedOrderItem");
 
             var order = (Order)Context["CreatedOrder"];
             var searchedOrderItem = new OrderItem().RetrieveByOrderId(Test.ConnectionString, order.OrderId);
-            searchedOrderItem.Should().BeNull();
+            searchedOrderItem.Should().BeEmpty();
         }
 
         [Then(@"the User is able to manage the Catalogue Solutions section")]

--- a/src/OrderFormAcceptanceTests.TestData/Order.cs
+++ b/src/OrderFormAcceptanceTests.TestData/Order.cs
@@ -100,7 +100,7 @@ namespace OrderFormAcceptanceTests.TestData
                                 ,@SupplierAddressId
                                 ,@SupplierContactId,
                                  @CatalogueSolutionsViewed,
-                                 @AdditionalServicesViewed
+                                 @AdditionalServicesViewed,
                                  @CommencementDate,
                                  @Created,
                                  @LastUpdated,

--- a/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/AssociatedServices.feature
+++ b/src/OrderFormAcceptanceTests.Tests/Features/ManageOrderForm/AssociatedServices.feature
@@ -6,12 +6,13 @@
 Background: 
 	Given an unsubmitted order exists
 	And the Associated Services section is not complete
-	@ignore
+
 Scenario: Associated Services - Sections presented
+	Given the Catalogue Solution section is complete
 	When the Order Form for the existing order is presented
 	Then there is the Associated Services section
 	And the User is able to manage the Associated Services section
-	@ignore
+
 Scenario: Associated Services - Service Recipient now complete, 0 Service Recipient
 	Given there are no Service Recipients in the order
 	And the Catalogue Solutions section is not complete
@@ -26,7 +27,7 @@ Scenario: Associated Services - Service Recipient now complete, 0 Service Recipi
 	And the Preview order summary button is enabled
 	And the Delete order button is enabled
 	And the Submit order button is disabled
-@ignore
+
 Scenario: Associated Services - Catalogue Solution now complete, >= 1 Service Recipient, 0 Catalogue Solution
 	Given there are one or more Service Recipients in the order
 	And the Catalogue Solution section is complete
@@ -78,7 +79,7 @@ Scenario: Associated Services - >= 1 Service Recipient, >=1 Catalogue Solution, 
 	And the Preview order summary button is enabled
 	And the Delete order button is enabled
 	And the Submit order button is disabled
-@ignore
+
 Scenario: Associated Services - Additional Service now complete, >= 1 Service Recipient, >=1 Catalogue Solution, 0 Additional Services
 	Given a Catalogue Solution is added to the order
 	And the Additional Services section is complete
@@ -96,7 +97,7 @@ Scenario: Associated Services - Additional Service now complete, >= 1 Service Re
 	And the Preview order summary button is enabled
 	And the Delete order button is enabled
 	And the Submit order button is disabled
-@ignore
+
 Scenario: Associated Services - Additional Service now complete, >= 1 Service Recipient, >=1 Catalogue Solution, =>1 Additional Service
 	Given a Catalogue Solution is added to the order
 	And an Additional Service is added to the order


### PR DESCRIPTION
[AB#8409](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/8409)
Enabled tests
Scenario Associated Services - Sections presented currently fails due to page title content incorrect, Ruth fixing in her next PR
Final Scenario: Associated Services - Select no Service Recipients and then go back and add service recipients remaining blocked as it's not possible as part of this story, I asked Josh to move the AC to the later story where associated services can be added, see story ticket comments